### PR TITLE
포스트 발행 여부 설정 기능 및 코드 블럭 관련 이슈 처리

### DIFF
--- a/src/contents/asdf-as-nodejs-version-manager.md
+++ b/src/contents/asdf-as-nodejs-version-manager.md
@@ -4,6 +4,7 @@ title: nvm에서 asdf로 갈아탄 후기
 summary: asdf의 장점은 무엇일까요?
 tags: ["asdf", "nodejs", "yarn"]
 created_at: 2024-01-11T10:19:37.725Z
+is_published: true
 ---
 
 여러 Nodejs 버전을 사용할 때 nvm으로 쉽게 버전을 변경할 수 있습니다. 

--- a/src/contents/review-blog-project.md
+++ b/src/contents/review-blog-project.md
@@ -4,6 +4,7 @@ title: 깃허브 블로그 만든 후기
 summary: 번들러 없이 블로그를 만들었습니다.
 tags: ["blog"]
 created_at: 2024-01-05T11:15:09.059Z
+is_published: true
 ---
 
 > 이번 프로젝트의 중점 사항은 *프레임워크 없이 개발하기* 였습니다.

--- a/src/contents/using-pug-and-tailwind.md
+++ b/src/contents/using-pug-and-tailwind.md
@@ -4,6 +4,7 @@ title: Pug와 TailwindCSS를 선택한 이유, 그리고 트러블슈팅
 summary: 둘은 잘못된 만남?
 tags: ["blog", "Pug", "TailwindCSS"]
 created_at: 2024-01-09T14:19:35.595Z
+is_published: true
 ---
 
 > 우선 현재 블로그의 스타일링에 사용하고 있는 기술 스택을 살펴봅니다.

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -4,6 +4,7 @@ export interface PostMetadata {
   summary: string;
   tags: string[];
   created_at: Date;
+  is_published: Boolean;
 }
 
 export interface Post extends PostMetadata {

--- a/src/scripts/buildFromMarkdown.ts
+++ b/src/scripts/buildFromMarkdown.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, writeFile } from "fs/promises";
+import { mkdir, readdir, rmdir, writeFile } from "fs/promises";
 import { renderHtmlFromMarkdown } from "./renderHtmlFromMarkdown";
 import config from "../config";
 
@@ -8,8 +8,15 @@ export async function buildFromMarkdown(path: string) {
   const files = await readdir(path);
   for (const file of files) {
     const dirName = file.split(".md")[0];
-    await mkdir(`${DOCS}/${POSTS}/${dirName}`);
-    const html = await renderHtmlFromMarkdown(`${path}/${file}`);
+    const dirPath = `${DOCS}/${POSTS}/${dirName}`;
+    await mkdir(dirPath);
+    const { isPublished, html } = await renderHtmlFromMarkdown(
+      `${path}/${file}`
+    );
+    if (!isPublished) {
+      await rmdir(dirPath);
+      return;
+    }
     await writeFile(`${DOCS}/${POSTS}/${dirName}/index.html`, html);
   }
 }

--- a/src/scripts/convertHtmlFromMarkdown.ts
+++ b/src/scripts/convertHtmlFromMarkdown.ts
@@ -1,10 +1,21 @@
 import Showdown from "showdown";
 import { utilityClassMap } from "../assets/style";
+import getClassNameFromHtmlClassAttribute from "../utility/getClassNameFromHtmlAttribute";
 
 const bindings = Object.keys(utilityClassMap).map((key) => ({
   type: "output",
   regex: new RegExp(`<${key}\\b([^>]*)>`, "g"),
-  replace: `<${key} class="${utilityClassMap[key]}" $1>`,
+  replace: (match: RegExp, group: string) => {
+    if (key === "code") {
+      const originClass =
+        group === "" ? "" : getClassNameFromHtmlClassAttribute(group);
+      return `<${key} class="${originClass} ${utilityClassMap[key]}">`;
+    }
+
+    return group === ""
+      ? `<${key} class="${utilityClassMap[key]}">`
+      : `<${key} class="${utilityClassMap[key]}" ${group}>`; // 리팩토링 : class, src, alt 를 분리해서 처리할 필요가 있다.
+  },
 }));
 
 export default function convertFromMarkdownToHtml(content: string) {

--- a/src/scripts/renderHtmlFromMarkdown.ts
+++ b/src/scripts/renderHtmlFromMarkdown.ts
@@ -23,13 +23,16 @@ export async function renderHtmlFromMarkdown(
   const createPostHtml = pug.compile(templateFile.toString(), {
     filename: templateFilePath,
   });
-  return createPostHtml({
-    post,
-    site: {
-      title: `${post.title} - Ben의 기술 블로그`,
-      title_for_sharing: `${post.title}`,
-      description: post.summary,
-      url: `https://benkim077.github.io/${post.slug}`,
-    },
-  });
+  return {
+    isPublished: post.is_published,
+    html: createPostHtml({
+      post,
+      site: {
+        title: `${post.title} - Ben의 기술 블로그`,
+        title_for_sharing: `${post.title}`,
+        description: post.summary,
+        url: `https://benkim077.github.io/${post.slug}`,
+      },
+    }),
+  };
 }

--- a/src/store/getMarkdownMetadata.ts
+++ b/src/store/getMarkdownMetadata.ts
@@ -2,16 +2,7 @@ import matter from "gray-matter";
 import { readFile } from "fs/promises";
 import { PostMetadata } from "../interfaces";
 
-export async function getMarkdownMetadata(path: string): Promise<PostMetadata> {
+export async function getMarkdownMetadata(path: string) {
   const file = await readFile(path);
-  const {
-    data: { slug, title, summary, tags, created_at },
-  } = matter(file);
-  return {
-    slug,
-    title,
-    summary,
-    tags,
-    created_at,
-  };
+  return matter(file).data as PostMetadata;
 }

--- a/src/test/utility.test.ts
+++ b/src/test/utility.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "@jest/globals";
+import getClassNameFromHtmlClassAttribute from "../utility/getClassNameFromHtmlAttribute";
+
+describe("getClassNameFromHtmlClassAttribute", () => {
+  test("Markdown Code Language Classes", () => {
+    expect(
+      getClassNameFromHtmlClassAttribute('class="html language-html"')
+    ).toBe("html language-html");
+  });
+
+  test("Utility Classes", () => {
+    expect(getClassNameFromHtmlClassAttribute('class="p-4 m-4 flex"')).toBe(
+      "p-4 m-4 flex"
+    );
+  });
+
+  test("Just a Class", () => {
+    expect(getClassNameFromHtmlClassAttribute('class="unique"')).toBe("unique");
+  });
+
+  test("Empty Class", () => {
+    expect(getClassNameFromHtmlClassAttribute('class=""')).toBe("");
+  });
+
+  // class attribute가 생략되는 경우, 이 함수를 사용하지 않는다. 그러므로 이런 테스트는 필요하지 않다.
+  // test("Empty String", () => {
+  //   expect(getClassNameFromHtmlClassAttribute("")).toBe("");
+  // })
+});

--- a/src/utility/getClassNameFromHtmlAttribute.ts
+++ b/src/utility/getClassNameFromHtmlAttribute.ts
@@ -1,0 +1,5 @@
+export default function getClassNameFromHtmlClassAttribute(
+  classAttribute: string
+) {
+  return classAttribute.trim().split('"')[1];
+}


### PR DESCRIPTION
### 포스트 발행 여부 설정 기능
- 마크다운 메타데이터에 is_published를 추가하였고, 이 값이 true인 포스트들만 html 파일을 생성합니다.

### 코드 블럭 관련 이슈 처리
- 여러 줄 코드 블럭의 class가 덮어씌워지는 과정에서 사라지는 이슈 발생 #36 
- Regex의 replace의 인자를 문자열에서 함수로 교체하여 분기처리하였습니다.
- getClassNameFromAttribute 함수를 분리 및 테스트 코드 작성
- 추가적으로 할 일 : class를 제외한 HTML attribute를 구분하여 처리하는 로직으로 리팩토링
